### PR TITLE
容器化部署测试

### DIFF
--- a/datalinkx-job/src/main/java/com/datalinkx/datajob/job/ExecutorJobHandler.java
+++ b/datalinkx-job/src/main/java/com/datalinkx/datajob/job/ExecutorJobHandler.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.util.IdUtil;
 import com.datalinkx.common.utils.JsonUtils;
+import com.datalinkx.common.utils.ObjectUtils;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
@@ -26,6 +27,12 @@ public class ExecutorJobHandler {
 
 	@Value("${flinkx.path}")
 	String flinkXHomePath;
+
+	@Value("${flinkx.syncplugins.path:${flinkx.path}}")
+	private String syncPluginsPath;
+
+	@Value("${flinkx.flinkconf.path:${flinkx.path}}")
+	private String flinkConf;
 
 	@Value("${reserve.job_graph:false}")
 	Boolean reserveJobGraph;
@@ -97,8 +104,8 @@ public class ExecutorJobHandler {
 				flinkXHomePath + (os.contains("win") ? "lib\\*" : "lib/*"),
 				jobId,
 				jobJsonFile,
-				flinkXHomePath + "syncplugins",
-				flinkXHomePath + "flinkconf"
+				syncPluginsPath.equals(flinkXHomePath) ? syncPluginsPath + "syncplugins" : syncPluginsPath,
+				flinkConf.equals(flinkXHomePath) ? flinkConf + "flinkconf" : flinkConf
 		);
 	}
 

--- a/datalinkx-job/src/main/resources/application.yml
+++ b/datalinkx-job/src/main/resources/application.yml
@@ -46,9 +46,26 @@ client:
     logging: true
 
 flinkx:
-  path: /Users/lixiaofei/work/datalinkX/flinkx/
+  path: ${user.dir}/flinkx/
+  #  如果使用容器化部署，请开启下面配置
 
+  #  syncplugins:
+  #    path: /datalinkx/flinkx/syncplugins/ #  这里填写“宿主机”`flinkx插件`挂载路径
+  #  flinkconf:
+  #    path: ${user.dir}/flinkx/flinkconf/ #  这里填写“容器内部”flinkconf的路径，请勿擅自修改
 
+  #  1.在容器内部创建与宿主机挂载的相同路径及文件
+  #   例如:
+  #   docker -v  /{dir_path}/flinkx/syncplugins:/datalinkx/flinkx/syncplugins
+  #
+  #   则需要进入容器内并创建/{dir_path}/flinkx/syncplugins相同路径及文件
+  #
+  #   参考命令
+  #
+  #    docker exec -it my_container /bin/bash && mkdir -p /{dir_path}/flinkx && exit
+  #    docker cp /{dir_path}/flinkx/syncplugins my_container:/{dir_path}/flinkx
+
+#  2.修改宿主机flinkconf的配置文件中的配置
 support:
   datasource:
     - mysql

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,14 @@
 FROM maven:3.6.3-openjdk-8
 
+#maven:3.6.3-openjdk-8中更换源debian:10
+
+RUN sed -i "1ideb https://mirrors.aliyun.com/debian/ buster main non-free contrib" /etc/apt/sources.list
+RUN sed -i "2ideb-src https://mirrors.aliyun.com/debian/ buster main non-free contrib" /etc/apt/sources.list
+RUN sed -i "3ideb https://mirrors.aliyun.com/debian-security buster/updates main" /etc/apt/sources.list
+RUN sed -i "4ideb-src https://mirrors.aliyun.com/debian-security buster/updates main" /etc/apt/sources.list
+RUN sed -i "5ideb https://mirrors.aliyun.com/debian/ buster-updates main non-free contrib" /etc/apt/sources.list
+RUN sed -i "6ideb-src https://mirrors.aliyun.com/debian/ buster-updates main non-free contrib" /etc/apt/sources.list
+
 RUN apt update && apt install git
 
 #切换目录，指定源码克隆后保存位置
@@ -20,8 +29,14 @@ WORKDIR /datalinkx
 VOLUME /datalinkx/datalinkx-server/config
 VOLUME /datalinkx/datalinkx-job/config
 
+#挂载flinkx配置地址
+VOLUME /datalinkx/flinkx/flinkconf
+
+#挂载flinkx插件地址
+VOLUME /datalinkx/flinkx/syncplugins
+
 #声明项目所用端口
-EXPOSE 12345 23456
+EXPOSE 12345 23456 9999
 
 #启动java项目程序
 CMD sh /datalinkx/bin/start.sh


### PR DESCRIPTION
1. 在Dockerfile中更换阿里源debian:10提升apt速度

2. 声明添加执行器端口9999

3. 修改datalink-job配置文件

   1. 添加syncplugins.path
   2. 添加flinkconf.path
   3. 添加容器化部署说明

4. 容器运行参考命令

   ```bash
     docker run -d -i \
     --name {container_name} \ 容器名称
     --network {container_network}\ 容器网络
     -p 12345:12345 \ 服务端口
     -p 23456:23456 \
     -p 9999:9999 \
     -v  /{dir_path}/datalinkx-server:/datalinkx/datalinkx-server/config \ 文件挂载
     -v  /{dir_path}/datalinkx-job:/datalinkx/datalinkx-job/config \
     -v  /{dir_path}/flinkx/flinkconf:/datalinkx/flinkx/flinkconf \
     -v  /{dir_path}/flinkx/syncplugins:/datalinkx/flinkx/syncplugins \
     datalinkx:v1 镜像名称
     ```